### PR TITLE
Fix issue #314: Added json_fwd.hpp.

### DIFF
--- a/src/json_fwd.hpp
+++ b/src/json_fwd.hpp
@@ -1,0 +1,30 @@
+#ifndef NLOHMANN_JSON_FWD_HPP
+#define NLOHMANN_JSON_FWD_HPP
+
+#include <cstdint>
+#include <map>
+#include <vector>
+#include <string>
+
+namespace nlohmann
+{
+
+template <
+    template<typename U, typename V, typename... Args> class ObjectType,
+    template<typename U, typename... Args> class ArrayType,
+    class StringType,
+    class BooleanType,
+    class NumberIntegerType,
+    class NumberUnsignedType,
+    class NumberFloatType,
+    template<typename U> class AllocatorType
+    >
+class basic_json;
+
+using json = basic_json<std::map,std::vector,std::string,bool,std::int64_t,
+                        std::uint64_t,double,std::allocator>;
+
+} // namespace nlohmann
+
+#endif // NLOHMANN_JSON_FWD_HPP
+


### PR DESCRIPTION
The issue asks: "Is there a way to forward declare nlohmann::json?"

This commits helps to do that. The added file helps to reduce compilation dependencies by providing a forward declaration of nlohmann::basic_json and a typedef for nlohmann::json.
